### PR TITLE
Modification keys: SHIFT and CTRL

### DIFF
--- a/PasteIntoFile/App.config
+++ b/PasteIntoFile/App.config
@@ -31,6 +31,9 @@
             <setting name="upgradePerformed" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="subdirTemplate" serializeAs="String">
+                <value>{0:yyyy-MM-dd}</value>
+            </setting>
         </PasteIntoFile.Properties.Settings>
     </userSettings>
 </configuration>

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -21,9 +21,9 @@ namespace PasteIntoFile
         
         public Dialog(string location, bool forceShowDialog = false)
         {
-            // invert autosave flag if shift is pressed during start
-            bool shiftPressed = (ModifierKeys & Keys.Shift) == Keys.Shift;
-            bool showDialog = forceShowDialog || !(Settings.Default.autoSave ^ shiftPressed);
+            // flag if key is pressed during start
+            bool invertAutosave = (ModifierKeys & Keys.Shift) == Keys.Shift;
+            bool saveIntoSubdir = (ModifierKeys & Keys.Control) == Keys.Control;
             
             // Setup GUI
             InitializeComponent();
@@ -59,6 +59,7 @@ namespace PasteIntoFile
             var clipRead = readClipboard();
             
             updateFilename();
+            if (saveIntoSubdir) location += @"\" + formatFilenameTemplate(Settings.Default.subdirTemplate);
             txtCurrentLocation.Text = location;
             chkClrClipboard.Checked = Settings.Default.clrClipboard;
             chkContinuousMode.Checked = continuousMode;
@@ -70,6 +71,7 @@ namespace PasteIntoFile
             txtFilename.Select();
 
             // show dialog or perform autosave
+            bool showDialog = forceShowDialog || !(Settings.Default.autoSave ^ invertAutosave);
             if (showDialog) {
                 // Make sure to bring window to foreground (holding shift will open window in background)
                 WindowState = FormWindowState.Minimized;
@@ -81,7 +83,8 @@ namespace PasteIntoFile
                 var file = clipRead ? save() : null;
                 if (file != null)
                 {
-                    ExplorerUtil.RequestFilenameEdit(file);
+                    if (!saveIntoSubdir)
+                        ExplorerUtil.RequestFilenameEdit(file);
                     
                     Program.ShowBalloon(Resources.str_autosave_balloontitle, 
                         new []{file, Resources.str_autosave_balloontext}, 10);

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -21,8 +21,9 @@ namespace PasteIntoFile
         
         public Dialog(string location, bool forceShowDialog = false)
         {
-            // always show GUI if shift pressed during start
-            forceShowDialog |= ModifierKeys == Keys.Shift;
+            // invert autosave flag if shift is pressed during start
+            bool shiftPressed = (ModifierKeys & Keys.Shift) == Keys.Shift;
+            bool showDialog = forceShowDialog || !(Settings.Default.autoSave ^ shiftPressed);
             
             // Setup GUI
             InitializeComponent();
@@ -58,7 +59,7 @@ namespace PasteIntoFile
             var clipRead = readClipboard();
             
             updateFilename();
-            txtCurrentLocation.Text = Path.GetFullPath(location);
+            txtCurrentLocation.Text = location;
             chkClrClipboard.Checked = Settings.Default.clrClipboard;
             chkContinuousMode.Checked = continuousMode;
             updateSavebutton(); 
@@ -68,18 +69,15 @@ namespace PasteIntoFile
 
             txtFilename.Select();
 
-            // show dialog or autosave option
-            if (forceShowDialog)
-            {
+            // show dialog or perform autosave
+            if (showDialog) {
                 // Make sure to bring window to foreground (holding shift will open window in background)
                 WindowState = FormWindowState.Minimized;
                 Show();
                 BringToFront();
                 WindowState = FormWindowState.Normal;
             }
-            // otherwise perform autosave if enabled
-            else if (Settings.Default.autoSave)
-            {
+            else {
                 var file = clipRead ? save() : null;
                 if (file != null)
                 {

--- a/PasteIntoFile/Main.cs
+++ b/PasteIntoFile/Main.cs
@@ -16,7 +16,9 @@ namespace PasteIntoFile
 
         class ArgsCommon
         {
-            [Option('f', "filename", HelpText = "Filename template with optional date format variable such as {0:yyyyMMdd HHmmSS}")]
+            [Option('f', "filename", HelpText = "Filename template with optional format variables such as\n" +
+                                                "{0:yyyyMMdd HHmmSS} for current date and time\n" +
+                                                "{1:000} for batch-mode save counter")]
             public string Filename { get; set; }
 
             [Option("text-extension", HelpText = "File extension for text contents")]
@@ -24,6 +26,9 @@ namespace PasteIntoFile
         
             [Option("image-extension", HelpText = "File extension for image contents")]
             public string ImageExtension { get; set; }
+            
+            [Option("subdir", HelpText = "Template for name of subfolder to create when holding CTRL (see filename for format variables)")]
+            public string Subdir { get; set; }
             
             [Option('c', "clear", HelpText = "Clear clipboard after save (true/false)")]
             public bool? ClearClipboard { get; set; }
@@ -217,6 +222,8 @@ namespace PasteIntoFile
                 Settings.Default.extensionText = args.TextExtension;
             if (args.ImageExtension != null)
                 Settings.Default.extensionImage = args.ImageExtension;
+            if (args.Subdir != null)
+                Settings.Default.subdirTemplate = args.Subdir;
             if (args.ClearClipboard != null)
                 Settings.Default.clrClipboard = (bool) args.ClearClipboard;
             if (args.Autosave != null)

--- a/PasteIntoFile/Properties/Resources.Designer.cs
+++ b/PasteIntoFile/Properties/Resources.Designer.cs
@@ -482,7 +482,7 @@ namespace PasteIntoFile.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can configure Paste Into File to automatically save the file without prompting for filename and extension. Instead, the file created will be selected for renaming in the explorer window. To show the dialog again, run the PasteInfoFile executable without arguments or hold the SHIFT key while selecting the context menu entry. You can change this setting later..
+        ///   Looks up a localized string similar to You can configure Paste Into File to automatically save the file. When enabled, the dialog prompting for filename and extension is skipped and the file will be created and selected for renaming in the explorer window instead. This setting can be changed later. To temporarily invert the setting, hold the SHIFT key when running Paste Into File. Note that the dialog is always shown when executing Paste Into File without command line arguments..
         /// </summary>
         internal static string str_wizard_autosave_info {
             get {

--- a/PasteIntoFile/Properties/Resources.de.resx
+++ b/PasteIntoFile/Properties/Resources.de.resx
@@ -91,7 +91,7 @@
         <value>Autosave aktivieren</value>
     </data>
     <data name="str_wizard_autosave_info" xml:space="preserve">
-        <value>Das Programm kann so konfiguriert werden, dass Dateien automatisch gespeichert werden, ohne dass der Dialog zur Eingabe von Dateinamen und -typ geöffnet wird. Stattdessen wird die erstellte Datei im Explorer zum Umbenennen markiert. Um den Dialog wieder anzuzeigen kann PasteIntoFile ohne Argumente ausgeführt werden, oder während des Programmstarts die Umschalttaste gedrückt gehalten werden. Diese Einstellung kann später angepasst werden.</value>
+        <value>Das Programm kann so konfiguriert werden, dass Dateien automatisch gespeichert werden. Dabei wird der Dialog zur Eingabe von Dateinamen und -typ übersprungen, und die erstellte Datei im Explorer zum Umbenennen markiert. Diese Einstellung kann später angepasst und jederzeit durch halten der Umschalttaste einmalig umgekehrt werden. Wenn Paste Into File ohne Argumente ausgeführt wird, wird der Dialog stets angezeigt.</value>
     </data>
     <data name="str_wizard_autosave_title" xml:space="preserve">
         <value>Datei automatisch ohne Dialog speichern?</value>

--- a/PasteIntoFile/Properties/Resources.resx
+++ b/PasteIntoFile/Properties/Resources.resx
@@ -219,7 +219,7 @@ Do you want to overwrite it?</value>
     <value>Finish setup</value>
   </data>
   <data name="str_wizard_autosave_info" xml:space="preserve">
-    <value>You can configure Paste Into File to automatically save the file without prompting for filename and extension. Instead, the file created will be selected for renaming in the explorer window. To show the dialog again, run the PasteInfoFile executable without arguments or hold the SHIFT key while selecting the context menu entry. You can change this setting later.</value>
+    <value>You can configure Paste Into File to automatically save the file. When enabled, the dialog prompting for filename and extension is skipped and the file will be created and selected for renaming in the explorer window instead. This setting can be changed later. To temporarily invert the setting, hold the SHIFT key when running Paste Into File. Note that the dialog is always shown when executing Paste Into File without command line arguments.</value>
   </data>
   <data name="str_continuous_mode" xml:space="preserve">
     <value>Batch mode</value>

--- a/PasteIntoFile/Properties/Settings.Designer.cs
+++ b/PasteIntoFile/Properties/Settings.Designer.cs
@@ -106,5 +106,17 @@ namespace PasteIntoFile.Properties {
                 this["upgradePerformed"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("{0:yyyy-MM-dd}")]
+        public string subdirTemplate {
+            get {
+                return ((string)(this["subdirTemplate"]));
+            }
+            set {
+                this["subdirTemplate"] = value;
+            }
+        }
     }
 }

--- a/PasteIntoFile/Properties/Settings.settings
+++ b/PasteIntoFile/Properties/Settings.settings
@@ -23,6 +23,9 @@
     <Setting Name="upgradePerformed" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="subdirTemplate" Type="System.String" Scope="User">
+      <Value Profile="(Default)">{0:yyyy-MM-dd}</Value>
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ PasteIntoFile 4.0.0.0
 Copyright © PasteIntoFile GitHub contributors
 
   -d, --directory      Path of directory to save file into
-  -f, --filename       Filename template with optional date format variable such
-                       as {0:yyyyMMdd HHmmSS}
+  -f, --filename       Filename template with optional format variables such as
+                       {0:yyyyMMdd HHmmSS} for current date and time
+                       {1:000} for batch-mode save counter
   --text-extension     File extension for text contents
   --image-extension    File extension for image contents
+  --subdir             Template for name of subfolder to create when holding
+                       CTRL (see filename for format variables)
   -c, --clear          Clear clipboard after save (true/false)
   -a, --autosave       Autosave file without prompt (true/false)
   --help               Display this help screen.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
 [![Latest release](https://img.shields.io/github/v/release/eltos/PasteIntoFile)](https://github.com/eltos/PasteIntoFile/releases/latest)
 [![Total downloads](https://img.shields.io/github/downloads/eltos/PasteIntoFile/total)](https://github.com/eltos/PasteIntoFile/releases)
 
+## About
+
 A Windows desktop application to paste clipboard contents into files and copy file contents to the clipboard via the context menu
 
-----------------
+
 
 _This is a fork of [sorge13248/PasteIntoFile](https://github.com/sorge13248/PasteIntoFile), itself being a fork of [EslaMx7/PasteIntoFile](https://github.com/EslaMx7/PasteIntoFile)._
 _See the [contributors page](https://github.com/eltos/PasteIntoFile/graphs/contributors) for details on collaborators._  
-
-_This fork contains many new core functionalities such as clipboard monitoring, batch mode and rename inside the file explorer. In addition, the GUI was completely redesigned to make the layout resizeable and allow for comfortable text and image preview._
+_This fork comes with many new features such as clipboard monitoring, batch mode, rename inside file explorer, copy file contents, paste into subdirectory, support for many additional formats and a new GUI with fluid layout and comfortable text, image, HTML and richt-text preview._
 _The full changelog can be found on the [release page](https://github.com/eltos/PasteIntoFile/releases)._
 
-----------------
+
 
 ## Features
 
@@ -47,13 +48,23 @@ Further options can be accessed through the main GUI or via command line options
 
 Help is available via [GitHub discussions](https://github.com/eltos/PasteIntoFile/discussions/categories/q-a) 
 
+### Key modifiers
+
+Hold the following keys while launching Paste Into File
+- **SHIFT** inverts autosave settings once  
+  When autosave is enabled, holding SHIFT will show the dialog anyways  
+  When autosave is disabled, holding SHIFT will skip the dialog anyways
+- **CTRL** saves to a subdirectory  
+  Holding CTRL will save to an intermediate subdirectory  
+  The subfolder name supports templates and can be configured via command line options
+
 
 ## Command Line Use
 
 Use `help`, `help paste`, `help config` etc. to show available command line options, e.g.:
-```powershell
+```
 > .\PasteIntoFile.exe help
-PasteIntoFile 4.0.0.0
+PasteIntoFile 4.2.0.0
 Copyright © PasteIntoFile GitHub contributors
 
   paste      (Default Verb) Paste clipboard contents into file
@@ -65,7 +76,7 @@ Copyright © PasteIntoFile GitHub contributors
 ```
 ```
 > .\PasteIntoFile.exe help paste
-PasteIntoFile 4.0.0.0
+PasteIntoFile 4.2.0.0
 Copyright © PasteIntoFile GitHub contributors
 
   -d, --directory      Path of directory to save file into


### PR DESCRIPTION
From discussions in https://github.com/eltos/PasteIntoFile/issues/6:
- Make SHIFT toggle automode 0a80d717d7c14aca7bdfbcc48ac696a7b7a1dc0d  
  When autosave is disabled, holding SHIFT will skip the dialog and save the file directly  
When autosave is enabled, holding SHIFT will show the dialog anyways  
- Add subdirectory option 768ee02fdf4610de236984f87a025b8a686e6be4  
  When holding CTRL, the file is saved in a subdirectory.  
  The name of the subdirectory can be configured via (template variables supported):
  ```ps
  .\PasteIntoFile.exe config --subdir "Subdir_{0:yyyyMMdd}"
  ```
  The explorer inline file rename for automode is disabled when saving to a subdirectory, since it would always open a new window which is undesireable


--------
Related:  
https://github.com/EslaMx7/PasteIntoFile/issues/44  
https://github.com/EslaMx7/PasteIntoFile/issues/12  
https://github.com/eltos/PasteIntoFile/issues/6