### PR TITLE
Add system tray mode and listen to global hotkey WIN+ALT+V

### DIFF
--- a/Installer/PasteIntoFile.wxs
+++ b/Installer/PasteIntoFile.wxs
@@ -109,6 +109,10 @@
           </RegistryKey>
         </RegistryKey>
       </RegistryKey>
+      <!-- for autostart -->
+      <RegistryKey Root='HKCU' Key='Software\Microsoft\Windows\CurrentVersion\Run'>
+        <RegistryValue Type='string' Name='PasteIntoFile' Value='"[INSTALLFOLDER]PasteIntoFile.exe" tray'/>
+      </RegistryKey>
     </Component>
   </Fragment>
 

--- a/PasteIntoFile/App.config
+++ b/PasteIntoFile/App.config
@@ -31,6 +31,9 @@
             <setting name="upgradePerformed" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="subdirTemplate" serializeAs="String">
+                <value>{0:yyyy-MM-dd}</value>
+            </setting>
         </PasteIntoFile.Properties.Settings>
     </userSettings>
 </configuration>

--- a/PasteIntoFile/Dialog.Designer.cs
+++ b/PasteIntoFile/Dialog.Designer.cs
@@ -55,7 +55,7 @@ namespace PasteIntoFile
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.chkContinuousMode = new System.Windows.Forms.CheckBox();
             this.tableLayoutPanel5 = new System.Windows.Forms.TableLayoutPanel();
-            this.chkContextEntry = new System.Windows.Forms.CheckBox();
+            this.settingsLinkLabel = new System.Windows.Forms.LinkLabel();
             ((System.ComponentModel.ISupportInitialize) (this.imagePreview)).BeginInit();
             this.box.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -383,7 +383,7 @@ namespace PasteIntoFile
             this.tableLayoutPanel5.Controls.Add(this.infoLinkLabel, 1, 1);
             this.tableLayoutPanel5.Controls.Add(this.chkAutoSave, 0, 0);
             this.tableLayoutPanel5.Controls.Add(this.infoLabel, 1, 0);
-            this.tableLayoutPanel5.Controls.Add(this.chkContextEntry, 0, 1);
+            this.tableLayoutPanel5.Controls.Add(this.settingsLinkLabel, 0, 1);
             this.tableLayoutPanel5.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel5.Location = new System.Drawing.Point(15, 471);
             this.tableLayoutPanel5.Margin = new System.Windows.Forms.Padding(0);
@@ -394,17 +394,18 @@ namespace PasteIntoFile
             this.tableLayoutPanel5.Size = new System.Drawing.Size(546, 56);
             this.tableLayoutPanel5.TabIndex = 14;
             // 
-            // chkContextEntry
+            // settingsLinkLabel
             // 
-            this.chkContextEntry.AutoSize = true;
-            this.chkContextEntry.Location = new System.Drawing.Point(4, 28);
-            this.chkContextEntry.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.chkContextEntry.Name = "chkContextEntry";
-            this.chkContextEntry.Size = new System.Drawing.Size(225, 24);
-            this.chkContextEntry.TabIndex = 8;
-            this.chkContextEntry.Text = "str_contextentry_checkbox";
-            this.chkContextEntry.UseVisualStyleBackColor = true;
-            this.chkContextEntry.CheckedChanged += new System.EventHandler(this.ChkContextEntry_CheckedChanged);
+            this.settingsLinkLabel.ActiveLinkColor = System.Drawing.SystemColors.Highlight;
+            this.settingsLinkLabel.AutoSize = true;
+            this.settingsLinkLabel.LinkColor = System.Drawing.SystemColors.ControlDark;
+            this.settingsLinkLabel.Location = new System.Drawing.Point(4, 28);
+            this.settingsLinkLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.settingsLinkLabel.Name = "settingsLinkLabel";
+            this.settingsLinkLabel.Size = new System.Drawing.Size(225, 24);
+            this.settingsLinkLabel.TabIndex = 8;
+            this.settingsLinkLabel.Text = "str_settings";
+            this.settingsLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.settingsLinkLabel_LinkClicked);
             // 
             // Dialog
             // 
@@ -438,7 +439,7 @@ namespace PasteIntoFile
         private System.Windows.Forms.LinkLabel linkLabel1;
 
         private System.Windows.Forms.CheckBox chkContinuousMode;
-        private System.Windows.Forms.CheckBox chkContextEntry;
+        private System.Windows.Forms.LinkLabel settingsLinkLabel;
         private System.Windows.Forms.PictureBox imagePreview;
         private System.Windows.Forms.RichTextBox textPreview;
         private System.Windows.Forms.WebBrowser htmlPreview;

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -21,9 +21,9 @@ namespace PasteIntoFile
         
         public Dialog(string location, bool forceShowDialog = false)
         {
-            // invert autosave flag if shift is pressed during start
-            bool shiftPressed = (ModifierKeys & Keys.Shift) == Keys.Shift;
-            bool showDialog = forceShowDialog || !(Settings.Default.autoSave ^ shiftPressed);
+            // flag if key is pressed during start
+            bool invertAutosave = (ModifierKeys & Keys.Shift) == Keys.Shift;
+            bool saveIntoSubdir = (ModifierKeys & Keys.Control) == Keys.Control;
             
             // Setup GUI
             InitializeComponent();
@@ -59,6 +59,7 @@ namespace PasteIntoFile
             var clipRead = readClipboard();
             
             updateFilename();
+            if (saveIntoSubdir) location += @"\" + formatFilenameTemplate(Settings.Default.subdirTemplate);
             txtCurrentLocation.Text = location;
             chkClrClipboard.Checked = Settings.Default.clrClipboard;
             chkContinuousMode.Checked = continuousMode;
@@ -70,6 +71,7 @@ namespace PasteIntoFile
             txtFilename.Select();
 
             // show dialog or perform autosave
+            bool showDialog = forceShowDialog || !(Settings.Default.autoSave ^ invertAutosave);
             if (showDialog) {
                 // Make sure to bring window to foreground (holding shift will open window in background)
                 WindowState = FormWindowState.Minimized;
@@ -81,7 +83,8 @@ namespace PasteIntoFile
                 var file = clipRead ? save() : null;
                 if (file != null)
                 {
-                    ExplorerUtil.RequestFilenameEdit(file);
+                    if (!saveIntoSubdir)
+                        ExplorerUtil.RequestFilenameEdit(file);
                     
                     Program.ShowBalloon(Resources.str_autosave_balloontitle, 
                         new []{file, Resources.str_autosave_balloontext}, 10);

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -19,8 +19,18 @@ namespace PasteIntoFile
         
         
         
-        public Dialog(string location, bool forceShowDialog = false)
+        public Dialog(string location = null, bool forceShowDialog = false)
         {
+            // Fallback to default path
+            location = (location?? ExplorerUtil.GetActiveExplorerPath()?? 
+                    Environment.GetFolderPath(Environment.SpecialFolder.Desktop))
+                .Trim().Trim("\"".ToCharArray()); // remove trailing " fixes paste in root dir
+            try {
+                location = Path.GetFullPath(location);
+            }
+            catch { // ignored
+            }
+            
             // flag if key is pressed during start
             bool invertAutosave = (ModifierKeys & Keys.Shift) == Keys.Shift;
             bool saveIntoSubdir = (ModifierKeys & Keys.Control) == Keys.Control;
@@ -89,11 +99,13 @@ namespace PasteIntoFile
                     Program.ShowBalloon(Resources.str_autosave_balloontitle, 
                         new []{file, Resources.str_autosave_balloontext}, 10);
 
-                    Environment.Exit(0);
+                    Environment.ExitCode = 0;
+                    Close();
                 }
                 else
                 {
-                    Environment.Exit(1);
+                    Environment.ExitCode = 1;
+                    Close();
                 }
 
             }
@@ -227,7 +239,8 @@ namespace PasteIntoFile
         {
             if (save() != null)
             {
-                Environment.Exit(0);
+                Environment.ExitCode = 0;
+                Close();
             }
         }
         
@@ -351,7 +364,8 @@ namespace PasteIntoFile
         {
             if (e.KeyChar == (char) Keys.Escape)
             {
-                Environment.Exit(1);
+                Environment.ExitCode = 0;
+                Close();
             }
         }
 

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -21,8 +21,9 @@ namespace PasteIntoFile
         
         public Dialog(string location, bool forceShowDialog = false)
         {
-            // always show GUI if shift pressed during start
-            forceShowDialog |= ModifierKeys == Keys.Shift;
+            // invert autosave flag if shift is pressed during start
+            bool shiftPressed = (ModifierKeys & Keys.Shift) == Keys.Shift;
+            bool showDialog = forceShowDialog || !(Settings.Default.autoSave ^ shiftPressed);
             
             // Setup GUI
             InitializeComponent();
@@ -58,7 +59,7 @@ namespace PasteIntoFile
             var clipRead = readClipboard();
             
             updateFilename();
-            txtCurrentLocation.Text = Path.GetFullPath(location);
+            txtCurrentLocation.Text = location;
             chkClrClipboard.Checked = Settings.Default.clrClipboard;
             chkContinuousMode.Checked = continuousMode;
             updateSavebutton(); 
@@ -68,18 +69,15 @@ namespace PasteIntoFile
 
             txtFilename.Select();
 
-            // show dialog or autosave option
-            if (forceShowDialog)
-            {
+            // show dialog or perform autosave
+            if (showDialog) {
                 // Make sure to bring window to foreground (holding shift will open window in background)
                 WindowState = FormWindowState.Minimized;
                 Show();
                 BringToFront();
                 WindowState = FormWindowState.Normal;
             }
-            // otherwise perform autosave if enabled
-            else if (Settings.Default.autoSave)
-            {
+            else {
                 var file = clipRead ? save() : null;
                 if (file != null)
                 {

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -75,7 +75,6 @@ namespace PasteIntoFile
             chkContinuousMode.Checked = continuousMode;
             updateSavebutton(); 
             chkAutoSave.Checked = Settings.Default.autoSave;
-            chkContextEntry.Checked = RegistryUtil.IsContextMenuEntryRegistered();
             
 
             txtFilename.Select();
@@ -368,25 +367,9 @@ namespace PasteIntoFile
 
         }
 
-        private void ChkContextEntry_CheckedChanged(object sender, EventArgs e)
+        private void settingsLinkLabel_LinkClicked(object sender, EventArgs e)
         {
-            try
-            {
-                if (chkContextEntry.Checked && !RegistryUtil.IsContextMenuEntryRegistered())
-                {
-                    RegistryUtil.RegisterContextMenuEntry();
-                    MessageBox.Show(Resources.str_message_register_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
-                }
-                else if (!chkContextEntry.Checked && RegistryUtil.IsContextMenuEntryRegistered())
-                {
-                    RegistryUtil.UnRegisterContextMenuEntry();
-                    MessageBox.Show(Resources.str_message_unregister_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
-                }
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show(ex.Message + "\n" + Resources.str_message_run_as_admin, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+            new Wizard().ShowDialog(this);
         }
 
         private void infoLinkLabel_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -75,7 +75,7 @@ namespace PasteIntoFile
             chkContinuousMode.Checked = continuousMode;
             updateSavebutton(); 
             chkAutoSave.Checked = Settings.Default.autoSave;
-            chkContextEntry.Checked = RegistryUtil.IsAppRegistered();
+            chkContextEntry.Checked = RegistryUtil.IsContextMenuEntryRegistered();
             
 
             txtFilename.Select();
@@ -372,14 +372,14 @@ namespace PasteIntoFile
         {
             try
             {
-                if (chkContextEntry.Checked && !RegistryUtil.IsAppRegistered())
+                if (chkContextEntry.Checked && !RegistryUtil.IsContextMenuEntryRegistered())
                 {
-                    RegistryUtil.RegisterApp();
+                    RegistryUtil.RegisterContextMenuEntry();
                     MessageBox.Show(Resources.str_message_register_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
-                else if (!chkContextEntry.Checked && RegistryUtil.IsAppRegistered())
+                else if (!chkContextEntry.Checked && RegistryUtil.IsContextMenuEntryRegistered())
                 {
-                    RegistryUtil.UnRegisterApp();
+                    RegistryUtil.UnRegisterContextMenuEntry();
                     MessageBox.Show(Resources.str_message_unregister_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }

--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -280,45 +280,7 @@ namespace PasteIntoFile
                 if (contentToSave != null) {
                     contentToSave.SaveAs(file, ext);
                 }
-                /*
-                else if (saveAs == Type.URL) {
-                    if (clipData.TextUrl == null) {
-                        MessageBox.Show(Resources.str_error_save_no_uri, Resources.str_main_window_title,
-                            MessageBoxButtons.OK, MessageBoxIcon.Error);
-                        return null;
-                    }
-                            
-                    File.WriteAllLines(file, new[] {
-                        @"[InternetShortcut]",
-                        @"URL=" + clipData.TextUrl
-                    }, Encoding.UTF8);
-                    
-                }
-                else if (saveAs == Type.SYLK && clipData.Sylk != null) {
-                    File.WriteAllText(file, clipData.Sylk, Encoding.ASCII);
-                }
-                else if (saveAs == Type.DIF && clipData.Dif != null) {
-                    File.WriteAllText(file, clipData.Dif, Encoding.ASCII);
-                }
-                else if (saveAs == Type.RTF && clipData.Rtf != null) {
-                    File.WriteAllText(file, clipData.Rtf, Encoding.ASCII);
-                }
-                else if (saveAs == Type.CSV && clipData.Csv != null) {
-                    File.WriteAllText(file, clipData.Csv, Encoding.UTF8);
-                }
-                else if (saveAs == Type.HTML && clipData.Html != null) {
-                    var data = clipData.Html;
-                    if (!data.StartsWith("<!DOCTYPE html>"))
-                        data = "<!DOCTYPE html>\n" + data;
-                    File.WriteAllText(file, data, Encoding.UTF8);
-                    
-                }
-                else if (saveAs.IsLikeText() && clipData.Text != null) // text like, e.g. allow to save text as html
-                {
-                    File.WriteAllText(file, clipData.Text, Encoding.UTF8);
-                }*/
-                else
-                {
+                else {
                     return null;
                 }
                 

--- a/PasteIntoFile/KeyboardHook.cs
+++ b/PasteIntoFile/KeyboardHook.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
+namespace PasteIntoFile {
+    /// <summary>
+    /// Register global Keyboard Hotkey
+    /// Thankfully taken from https://stackoverflow.com/a/27309185/13324744
+    /// </summary>
+    public sealed  class KeyboardHook : IDisposable
+    {
+        // Registers a hot key with Windows.
+        [DllImport("user32.dll")]
+        private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+        // Unregisters the hot key with Windows.
+        [DllImport("user32.dll")]
+        private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+        /// <summary>
+        /// Represents the window that is used internally to get the messages.
+        /// </summary>
+        private class Window : NativeWindow, IDisposable
+        {
+            private static int WM_HOTKEY = 0x0312;
+
+            public Window()
+            {
+                // create the handle for the window.
+                CreateHandle(new CreateParams());
+            }
+
+            /// <summary>
+            /// Overridden to get the notifications.
+            /// </summary>
+            /// <param name="m"></param>
+            protected override void WndProc(ref Message m)
+            {
+                base.WndProc(ref m);
+
+                // check if we got a hot key pressed.
+                if (m.Msg == WM_HOTKEY)
+                {
+                    // get the keys.
+                    Keys key = (Keys)(((int)m.LParam >> 16) & 0xFFFF);
+                    ModifierKeys modifier = (ModifierKeys)((int)m.LParam & 0xFFFF);
+
+                    // invoke the event to notify the parent.
+                    if (KeyPressed != null)
+                        KeyPressed(this, new KeyPressedEventArgs(modifier, key));
+                }
+            }
+
+            public event EventHandler<KeyPressedEventArgs> KeyPressed;
+
+            #region IDisposable Members
+
+            public void Dispose()
+            {
+                DestroyHandle();
+            }
+
+            #endregion
+        }
+
+        private Window _window = new Window();
+        private int _currentId;
+
+        public KeyboardHook()
+        {
+            // register the event of the inner native window.
+            _window.KeyPressed += delegate(object sender, KeyPressedEventArgs args)
+            {
+                if (KeyPressed != null)
+                    KeyPressed(this, args);
+            };
+        }
+
+        /// <summary>
+        /// Registers a hot key in the system.
+        /// </summary>
+        /// <param name="modifier">The modifiers that are associated with the hot key.</param>
+        /// <param name="key">The key itself that is associated with the hot key.</param>
+        public void RegisterHotKey(ModifierKeys modifier, Keys key)
+        {
+            // increment the counter.
+            _currentId += 1;
+
+            // register the hot key.
+            if (!RegisterHotKey(_window.Handle, _currentId, (uint)modifier, (uint)key))
+                throw new InvalidOperationException("Couldn’t register the hot key.");
+        }
+
+        /// <summary>
+        /// A hot key has been pressed.
+        /// </summary>
+        public event EventHandler<KeyPressedEventArgs> KeyPressed;
+
+        #region IDisposable Members
+
+        public void Dispose()
+        {
+            // unregister all the registered hot keys.
+            for (int i = _currentId; i > 0; i--)
+            {
+                UnregisterHotKey(_window.Handle, i);
+            }
+
+            // dispose the inner native window.
+            _window.Dispose();
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Event Args for the event that is fired after the hot key has been pressed.
+    /// </summary>
+    public class KeyPressedEventArgs : EventArgs
+    {
+        private ModifierKeys _modifier;
+        private Keys _key;
+
+        internal KeyPressedEventArgs(ModifierKeys modifier, Keys key)
+        {
+            _modifier = modifier;
+            _key = key;
+        }
+
+        public ModifierKeys Modifier => _modifier;
+
+        public Keys Key => _key;
+    }
+
+    /// <summary>
+    /// The enumeration of possible modifiers.
+    /// </summary>
+    [Flags]
+    public enum ModifierKeys : uint
+    {
+        Alt = 1,
+        Control = 2,
+        Shift = 4,
+        Win = 8
+    }
+}

--- a/PasteIntoFile/Main.cs
+++ b/PasteIntoFile/Main.cs
@@ -61,10 +61,16 @@ namespace PasteIntoFile
         class ArgsConfig : ArgsCommon
         {
             [Option("register", HelpText = "Register context menu entry", SetName = "register")]
-            public bool Register { get; set; }
+            public bool RegisterContextMenu { get; set; }
 
             [Option("unregister", HelpText = "Unregister context menu entry", SetName = "register")]
-            public bool Unregister { get; set; }
+            public bool UnregisterContextMenu { get; set; }
+            
+            [Option("enable-autostart", HelpText = "Register program to run in system tray on windows startup", SetName = "autostart")]
+            public bool RegisterAutostart { get; set; }
+
+            [Option("disable-autostart", HelpText = "Remove autostart on windows startup registration", SetName = "autostart")]
+            public bool UnregisterAutostart { get; set; }
             
         }
 
@@ -204,8 +210,8 @@ namespace PasteIntoFile
         /// <returns>Exit code</returns>
         static int RunWizard(ArgsWizard args = null)
         {
-            if (RegistryUtil.IsAppRegistered())
-                RegistryUtil.RegisterApp(); // overwrites default entry with localized strings
+            if (RegistryUtil.IsContextMenuEntryRegistered())
+                RegistryUtil.RegisterContextMenuEntry(); // overwrites default entry with localized strings
             
             Application.Run(new Wizard());
             return 0;
@@ -274,10 +280,14 @@ namespace PasteIntoFile
             ApplyCommonArgs(args);
             try
             {
-                if (args.Register)
-                    RegistryUtil.RegisterApp();
-                if (args.Unregister)
-                    RegistryUtil.UnRegisterApp();
+                if (args.RegisterContextMenu)
+                    RegistryUtil.RegisterContextMenuEntry();
+                if (args.UnregisterContextMenu)
+                    RegistryUtil.UnRegisterContextMenuEntry();
+                if (args.RegisterAutostart)
+                    RegistryUtil.RegisterAutostart();
+                if (args.UnregisterAutostart)
+                    RegistryUtil.UnRegisterAutostart();
             }
             catch (Exception ex)
             {

--- a/PasteIntoFile/Main.cs
+++ b/PasteIntoFile/Main.cs
@@ -241,6 +241,7 @@ namespace PasteIntoFile
             icon.Text = Resources.str_main_window_title;
             icon.ContextMenu = new ContextMenu(new[] {
                 new MenuItem(Resources.str_open_paste_into_file, (s, e) => new Dialog(forceShowDialog: true).Show()),
+                new MenuItem(Resources.str_settings, (s, e) => new Wizard().Show()),
                 new MenuItem(Resources.str_exit, (s, e) => { Application.Exit(); }),
             });
             icon.Visible = true;

--- a/PasteIntoFile/Main.cs
+++ b/PasteIntoFile/Main.cs
@@ -16,7 +16,9 @@ namespace PasteIntoFile
 
         class ArgsCommon
         {
-            [Option('f', "filename", HelpText = "Filename template with optional date format variable such as {0:yyyyMMdd HHmmSS}")]
+            [Option('f', "filename", HelpText = "Filename template with optional format variables such as\n" +
+                                                "{0:yyyyMMdd HHmmSS} for current date and time\n" +
+                                                "{1:000} for batch-mode save counter")]
             public string Filename { get; set; }
 
             [Option("text-extension", HelpText = "File extension for text contents")]
@@ -24,6 +26,9 @@ namespace PasteIntoFile
         
             [Option("image-extension", HelpText = "File extension for image contents")]
             public string ImageExtension { get; set; }
+            
+            [Option("subdir", HelpText = "Template for name of subfolder to create when holding CTRL (see filename for format variables)")]
+            public string Subdir { get; set; }
             
             [Option('c', "clear", HelpText = "Clear clipboard after save (true/false)")]
             public bool? ClearClipboard { get; set; }
@@ -217,6 +222,8 @@ namespace PasteIntoFile
                 Settings.Default.extensionText = args.TextExtension;
             if (args.ImageExtension != null)
                 Settings.Default.extensionImage = args.ImageExtension;
+            if (args.Subdir != null)
+                Settings.Default.subdirTemplate = args.Subdir;
             if (args.ClearClipboard != null)
                 Settings.Default.clrClipboard = (bool) args.ClearClipboard;
             if (args.Autosave != null)

--- a/PasteIntoFile/PasteIntoFile.csproj
+++ b/PasteIntoFile/PasteIntoFile.csproj
@@ -88,6 +88,7 @@
   <ItemGroup>
     <Compile Include="ClipboardContents.cs" />
     <Compile Include="ExplorerUtil.cs" />
+    <Compile Include="KeyboardHook.cs" />
     <Compile Include="MasterForm.cs" />
     <Compile Include="RegistryUtil.cs" />
     <Compile Include="SeparableComboBox.cs">

--- a/PasteIntoFile/Properties/Resources.Designer.cs
+++ b/PasteIntoFile/Properties/Resources.Designer.cs
@@ -208,6 +208,15 @@ namespace PasteIntoFile.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exit.
+        /// </summary>
+        internal static string str_exit {
+            get {
+                return ResourceManager.GetString("str_exit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Extension.
         /// </summary>
         internal static string str_extension {
@@ -340,6 +349,15 @@ namespace PasteIntoFile.Properties {
         internal static string str_noclip_text {
             get {
                 return ResourceManager.GetString("str_noclip_text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Paste Into File.
+        /// </summary>
+        internal static string str_open_paste_into_file {
+            get {
+                return ResourceManager.GetString("str_open_paste_into_file", resourceCulture);
             }
         }
         

--- a/PasteIntoFile/Properties/Resources.Designer.cs
+++ b/PasteIntoFile/Properties/Resources.Designer.cs
@@ -482,7 +482,7 @@ namespace PasteIntoFile.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to You can configure Paste Into File to automatically save the file without prompting for filename and extension. Instead, the file created will be selected for renaming in the explorer window. To show the dialog again, run the PasteInfoFile executable without arguments or hold the SHIFT key while selecting the context menu entry. You can change this setting later..
+        ///   Looks up a localized string similar to You can configure Paste Into File to automatically save the file. When enabled, the dialog prompting for filename and extension is skipped and the file will be created and selected for renaming in the explorer window instead. This setting can be changed later. To temporarily invert the setting, hold the SHIFT key when running Paste Into File. Note that the dialog is always shown when executing Paste Into File without command line arguments..
         /// </summary>
         internal static string str_wizard_autosave_info {
             get {

--- a/PasteIntoFile/Properties/Resources.Designer.cs
+++ b/PasteIntoFile/Properties/Resources.Designer.cs
@@ -461,6 +461,15 @@ namespace PasteIntoFile.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Settings.
+        /// </summary>
+        internal static string str_settings {
+            get {
+                return ResourceManager.GetString("str_settings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The template is used to format the filename. The following variables are supported:
         ///  {0} - Date and time
         ///  {1} - Save count in batch mode

--- a/PasteIntoFile/Properties/Resources.Designer.cs
+++ b/PasteIntoFile/Properties/Resources.Designer.cs
@@ -308,6 +308,15 @@ namespace PasteIntoFile.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Autostart registered.
+        /// </summary>
+        internal static string str_message_register_autostart_success {
+            get {
+                return ResourceManager.GetString("str_message_register_autostart_success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Explorer context menu entry has been added.
         /// </summary>
         internal static string str_message_register_context_menu_success {
@@ -322,6 +331,15 @@ namespace PasteIntoFile.Properties {
         internal static string str_message_run_as_admin {
             get {
                 return ResourceManager.GetString("str_message_run_as_admin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Autostart unregistered.
+        /// </summary>
+        internal static string str_message_unregister_autostart_success {
+            get {
+                return ResourceManager.GetString("str_message_unregister_autostart_success", resourceCulture);
             }
         }
         
@@ -523,6 +541,33 @@ namespace PasteIntoFile.Properties {
         internal static string str_wizard_autosave_title {
             get {
                 return ResourceManager.GetString("str_wizard_autosave_title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Register autostart.
+        /// </summary>
+        internal static string str_wizard_autostart_button {
+            get {
+                return ResourceManager.GetString("str_wizard_autostart_button", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To paste clipboard contents by pressing WIN+ALT+V, Paste Into File needs to run in the system tray. If enabled, it will run automatically on windows startup and listen for the hotkey. This setting will take effect on the next login..
+        /// </summary>
+        internal static string str_wizard_autostart_info {
+            get {
+                return ResourceManager.GetString("str_wizard_autostart_info", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable autostart and hotkey WIN+ALT+V?.
+        /// </summary>
+        internal static string str_wizard_autostart_title {
+            get {
+                return ResourceManager.GetString("str_wizard_autostart_title", resourceCulture);
             }
         }
         

--- a/PasteIntoFile/Properties/Resources.de.resx
+++ b/PasteIntoFile/Properties/Resources.de.resx
@@ -91,7 +91,7 @@
         <value>Autosave aktivieren</value>
     </data>
     <data name="str_wizard_autosave_info" xml:space="preserve">
-        <value>Das Programm kann so konfiguriert werden, dass Dateien automatisch gespeichert werden, ohne dass der Dialog zur Eingabe von Dateinamen und -typ geöffnet wird. Stattdessen wird die erstellte Datei im Explorer zum Umbenennen markiert. Um den Dialog wieder anzuzeigen kann PasteIntoFile ohne Argumente ausgeführt werden, oder während des Programmstarts die Umschalttaste gedrückt gehalten werden. Diese Einstellung kann später angepasst werden.</value>
+        <value>Das Programm kann so konfiguriert werden, dass Dateien automatisch gespeichert werden. Dabei wird der Dialog zur Eingabe von Dateinamen und -typ übersprungen, und die erstellte Datei im Explorer zum Umbenennen markiert. Diese Einstellung kann später angepasst und jederzeit durch halten der Umschalttaste einmalig umgekehrt werden. Wenn Paste Into File ohne Argumente ausgeführt wird, wird der Dialog stets angezeigt.</value>
     </data>
     <data name="str_wizard_autosave_title" xml:space="preserve">
         <value>Datei automatisch ohne Dialog speichern?</value>

--- a/PasteIntoFile/Properties/Resources.de.resx
+++ b/PasteIntoFile/Properties/Resources.de.resx
@@ -179,4 +179,7 @@ Für Details zur Formatierung &lt;a&gt;hier klicken&lt;/a&gt;.</value>
     <data name="str_open_paste_into_file" xml:space="preserve">
         <value>Paste Into File öffnen</value>
     </data>
+    <data name="str_settings" xml:space="preserve">
+        <value>Einstellungen</value>
+    </data>
 </root>

--- a/PasteIntoFile/Properties/Resources.de.resx
+++ b/PasteIntoFile/Properties/Resources.de.resx
@@ -173,4 +173,10 @@ Für Details zur Formatierung &lt;a&gt;hier klicken&lt;/a&gt;.</value>
     <data name="str_preview_dif" xml:space="preserve">
         <value>Data Interchange Vorschau</value>
     </data>
+    <data name="str_exit" xml:space="preserve">
+        <value>Beenden</value>
+    </data>
+    <data name="str_open_paste_into_file" xml:space="preserve">
+        <value>Paste Into File öffnen</value>
+    </data>
 </root>

--- a/PasteIntoFile/Properties/Resources.de.resx
+++ b/PasteIntoFile/Properties/Resources.de.resx
@@ -182,4 +182,19 @@ Für Details zur Formatierung &lt;a&gt;hier klicken&lt;/a&gt;.</value>
     <data name="str_settings" xml:space="preserve">
         <value>Einstellungen</value>
     </data>
+    <data name="str_wizard_autostart_button" xml:space="preserve">
+        <value>Autostart registieren</value>
+    </data>
+    <data name="str_wizard_autostart_title" xml:space="preserve">
+        <value>Autostart und Tastenkürzel WIN+ALT+V aktivieren?</value>
+    </data>
+    <data name="str_wizard_autostart_info" xml:space="preserve">
+        <value>Um Inhalte der Zwischenablage durch Drücken von WIN+ALT+V als Datei einzufügen muss Paste Into File im System-Tray laufen. Wenn diese Option aktiviert ist, wird das Program ab dem nächsten Systemstart automatisch mit Windows gestartet und auf das Tastenkürzel reagieren.</value>
+    </data>
+    <data name="str_message_register_autostart_success" xml:space="preserve">
+        <value>Autostart aktiviert</value>
+    </data>
+    <data name="str_message_unregister_autostart_success" xml:space="preserve">
+        <value>Autostart deaktiviert</value>
+    </data>
 </root>

--- a/PasteIntoFile/Properties/Resources.resx
+++ b/PasteIntoFile/Properties/Resources.resx
@@ -292,4 +292,19 @@ Save current clipboard contents now?</value>
   <data name="str_settings" xml:space="preserve">
     <value>Settings</value>
   </data>
+  <data name="str_message_register_autostart_success" xml:space="preserve">
+    <value>Autostart registered</value>
+  </data>
+  <data name="str_message_unregister_autostart_success" xml:space="preserve">
+    <value>Autostart unregistered</value>
+  </data>
+  <data name="str_wizard_autostart_title" xml:space="preserve">
+    <value>Enable autostart and hotkey WIN+ALT+V?</value>
+  </data>
+  <data name="str_wizard_autostart_button" xml:space="preserve">
+    <value>Register autostart</value>
+  </data>
+  <data name="str_wizard_autostart_info" xml:space="preserve">
+    <value>To paste clipboard contents by pressing WIN+ALT+V, Paste Into File needs to run in the system tray. If enabled, it will run automatically on windows startup and listen for the hotkey. This setting will take effect on the next login.</value>
+  </data>
 </root>

--- a/PasteIntoFile/Properties/Resources.resx
+++ b/PasteIntoFile/Properties/Resources.resx
@@ -283,4 +283,10 @@ Save current clipboard contents now?</value>
   <data name="str_preview_dif" xml:space="preserve">
     <value>Data Interchange preview</value>
   </data>
+  <data name="str_exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="str_open_paste_into_file" xml:space="preserve">
+    <value>Open Paste Into File</value>
+  </data>
 </root>

--- a/PasteIntoFile/Properties/Resources.resx
+++ b/PasteIntoFile/Properties/Resources.resx
@@ -219,7 +219,7 @@ Do you want to overwrite it?</value>
     <value>Finish setup</value>
   </data>
   <data name="str_wizard_autosave_info" xml:space="preserve">
-    <value>You can configure Paste Into File to automatically save the file without prompting for filename and extension. Instead, the file created will be selected for renaming in the explorer window. To show the dialog again, run the PasteInfoFile executable without arguments or hold the SHIFT key while selecting the context menu entry. You can change this setting later.</value>
+    <value>You can configure Paste Into File to automatically save the file. When enabled, the dialog prompting for filename and extension is skipped and the file will be created and selected for renaming in the explorer window instead. This setting can be changed later. To temporarily invert the setting, hold the SHIFT key when running Paste Into File. Note that the dialog is always shown when executing Paste Into File without command line arguments.</value>
   </data>
   <data name="str_continuous_mode" xml:space="preserve">
     <value>Batch mode</value>

--- a/PasteIntoFile/Properties/Resources.resx
+++ b/PasteIntoFile/Properties/Resources.resx
@@ -289,4 +289,7 @@ Save current clipboard contents now?</value>
   <data name="str_open_paste_into_file" xml:space="preserve">
     <value>Open Paste Into File</value>
   </data>
+  <data name="str_settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
 </root>

--- a/PasteIntoFile/Properties/Settings.Designer.cs
+++ b/PasteIntoFile/Properties/Settings.Designer.cs
@@ -106,5 +106,17 @@ namespace PasteIntoFile.Properties {
                 this["upgradePerformed"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("{0:yyyy-MM-dd}")]
+        public string subdirTemplate {
+            get {
+                return ((string)(this["subdirTemplate"]));
+            }
+            set {
+                this["subdirTemplate"] = value;
+            }
+        }
     }
 }

--- a/PasteIntoFile/Properties/Settings.settings
+++ b/PasteIntoFile/Properties/Settings.settings
@@ -23,6 +23,9 @@
     <Setting Name="upgradePerformed" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="subdirTemplate" Type="System.String" Scope="User">
+      <Value Profile="(Default)">{0:yyyy-MM-dd}</Value>
+    </Setting>
   </Settings>
 </SettingsFile>
 

--- a/PasteIntoFile/RegistryUtil.cs
+++ b/PasteIntoFile/RegistryUtil.cs
@@ -50,8 +50,8 @@ namespace PasteIntoFile
         /// <summary>
         /// Checks if context menu entry is registered
         /// </summary>
-        /// <returns>app registration status (true/false)</returns>
-        public static bool IsAppRegistered()
+        /// <returns>context menu entry registration status (true/false)</returns>
+        public static bool IsContextMenuEntryRegistered()
         {
 	        foreach (var classKey in OpenClassKeys())
 	        {
@@ -63,7 +63,7 @@ namespace PasteIntoFile
         /// <summary>
         /// Remove context menu entry
         /// </summary>
-        public static void UnRegisterApp()
+        public static void UnRegisterContextMenuEntry()
         {
 	        foreach (var classKey in OpenClassKeys())
 	        {
@@ -74,7 +74,7 @@ namespace PasteIntoFile
         /// <summary>
         /// Create context menu entry
         /// </summary>
-        public static void RegisterApp(bool silent = false)
+        public static void RegisterContextMenuEntry(bool silent = false)
         {
 	        // Documentation:
 	        // https://docs.microsoft.com/en-us/windows/win32/shell/context
@@ -102,6 +102,33 @@ namespace PasteIntoFile
 
 	        }
 
+        }
+
+        /// <summary>
+        /// Checks if autostart is registered
+        /// </summary>
+        /// <returns>autostart registration status (true/false)</returns>
+        public static bool IsAutostartRegistered() {
+	        return Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true)?
+		        .GetValue(PRIMARY_KEY_NAME) != null;
+        }
+        
+        /// <summary>
+        /// Register autostart
+        /// </summary>
+        public static void RegisterAutostart() {
+	        // The path to the key where Windows looks for startup applications
+	        Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true)?
+		        .SetValue(PRIMARY_KEY_NAME, "\"" + Application.ExecutablePath + "\" tray");
+        }
+        
+        /// <summary>
+        /// Remove autostart registration
+        /// </summary>
+        public static void UnRegisterAutostart() {
+	        // The path to the key where Windows looks for startup applications
+	        Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true)?
+		        .DeleteValue(PRIMARY_KEY_NAME, false);
         }
 
     }

--- a/PasteIntoFile/Wizard.Designer.cs
+++ b/PasteIntoFile/Wizard.Designer.cs
@@ -32,13 +32,16 @@ namespace PasteIntoFile
         private void InitializeComponent()
         {
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.chkAutoSave = new System.Windows.Forms.CheckBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.label1 = new System.Windows.Forms.Label();
+            this.autoSaveCheckBox = new System.Windows.Forms.CheckBox();
+            this.autoSaveInfoLabel = new System.Windows.Forms.Label();
+            this.autoSaveTitleLabel = new System.Windows.Forms.Label();
+            this.autostartCheckBox = new System.Windows.Forms.CheckBox();
+            this.autostartInfoLabel = new System.Windows.Forms.Label();
+            this.autostartTitleLabel = new System.Windows.Forms.Label();
             this.title = new System.Windows.Forms.Label();
-            this.subtitle1 = new System.Windows.Forms.Label();
-            this.text1 = new System.Windows.Forms.Label();
-            this.chkContextEntry = new System.Windows.Forms.CheckBox();
+            this.contextEntryTitleLabel = new System.Windows.Forms.Label();
+            this.contextEntryInfoLabel = new System.Windows.Forms.Label();
+            this.contextEntryCheckBox = new System.Windows.Forms.CheckBox();
             this.finish = new System.Windows.Forms.Button();
             this.version = new System.Windows.Forms.Label();
             this.tableLayoutPanel1.SuspendLayout();
@@ -48,15 +51,18 @@ namespace PasteIntoFile
             // 
             this.tableLayoutPanel1.ColumnCount = 1;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.chkAutoSave, 0, 7);
-            this.tableLayoutPanel1.Controls.Add(this.label2, 0, 6);
-            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 5);
             this.tableLayoutPanel1.Controls.Add(this.title, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.subtitle1, 0, 2);
-            this.tableLayoutPanel1.Controls.Add(this.text1, 0, 3);
-            this.tableLayoutPanel1.Controls.Add(this.chkContextEntry, 0, 4);
-            this.tableLayoutPanel1.Controls.Add(this.finish, 0, 8);
             this.tableLayoutPanel1.Controls.Add(this.version, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.contextEntryTitleLabel, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.contextEntryInfoLabel, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.contextEntryCheckBox, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.autoSaveTitleLabel, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.autoSaveInfoLabel, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.autoSaveCheckBox, 0, 7);
+            this.tableLayoutPanel1.Controls.Add(this.autostartTitleLabel, 0, 8);
+            this.tableLayoutPanel1.Controls.Add(this.autostartInfoLabel, 0, 9);
+            this.tableLayoutPanel1.Controls.Add(this.autostartCheckBox, 0, 10);
+            this.tableLayoutPanel1.Controls.Add(this.finish, 0, 11);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
@@ -72,47 +78,50 @@ namespace PasteIntoFile
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(576, 542);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(600, 800);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
-            // chkAutoSave
+            // autoSaveCheckBox
             // 
-            this.chkAutoSave.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkAutoSave.AutoSize = true;
-            this.chkAutoSave.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.chkAutoSave.Location = new System.Drawing.Point(301, 331);
-            this.chkAutoSave.Margin = new System.Windows.Forms.Padding(9);
-            this.chkAutoSave.Name = "chkAutoSave";
-            this.chkAutoSave.Size = new System.Drawing.Size(262, 24);
-            this.chkAutoSave.TabIndex = 1;
-            this.chkAutoSave.Text = "str_wizard_autosave_button";
-            this.chkAutoSave.UseVisualStyleBackColor = true;
-            this.chkAutoSave.CheckedChanged += new System.EventHandler(this.ChkAutoSave_CheckedChanged);
+            this.autoSaveCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.autoSaveCheckBox.AutoSize = true;
+            this.autoSaveCheckBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.autoSaveCheckBox.Location = new System.Drawing.Point(301, 331);
+            this.autoSaveCheckBox.Margin = new System.Windows.Forms.Padding(9);
+            this.autoSaveCheckBox.Name = "autoSaveCheckBox";
+            this.autoSaveCheckBox.Size = new System.Drawing.Size(262, 24);
+            this.autoSaveCheckBox.TabIndex = 1;
+            this.autoSaveCheckBox.Text = "str_wizard_autosave_button";
+            this.autoSaveCheckBox.UseVisualStyleBackColor = true;
+            this.autoSaveCheckBox.CheckedChanged += new System.EventHandler(this.ChkAutoSave_CheckedChanged);
             // 
-            // label2
+            // autoSaveInfoLabel
             // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.label2.Location = new System.Drawing.Point(8, 295);
-            this.label2.Margin = new System.Windows.Forms.Padding(4);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(560, 23);
-            this.label2.TabIndex = 6;
-            this.label2.Text = "str_wizard_autosave_info";
+            this.autoSaveInfoLabel.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.autoSaveInfoLabel.AutoSize = true;
+            this.autoSaveInfoLabel.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.autoSaveInfoLabel.Location = new System.Drawing.Point(8, 295);
+            this.autoSaveInfoLabel.Margin = new System.Windows.Forms.Padding(4);
+            this.autoSaveInfoLabel.Name = "autoSaveInfoLabel";
+            this.autoSaveInfoLabel.Size = new System.Drawing.Size(560, 23);
+            this.autoSaveInfoLabel.TabIndex = 6;
+            this.autoSaveInfoLabel.Text = "str_wizard_autosave_info";
             // 
-            // label1
+            // autoSaveTitleLabel
             // 
-            this.label1.AutoSize = true;
-            this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.label1.Location = new System.Drawing.Point(8, 255);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 30, 4, 4);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(560, 32);
-            this.label1.TabIndex = 5;
-            this.label1.Text = "str_wizard_autosave_title";
+            this.autoSaveTitleLabel.AutoSize = true;
+            this.autoSaveTitleLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.autoSaveTitleLabel.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.autoSaveTitleLabel.Location = new System.Drawing.Point(8, 255);
+            this.autoSaveTitleLabel.Margin = new System.Windows.Forms.Padding(4, 30, 4, 4);
+            this.autoSaveTitleLabel.Name = "autoSaveTitleLabel";
+            this.autoSaveTitleLabel.Size = new System.Drawing.Size(560, 32);
+            this.autoSaveTitleLabel.TabIndex = 5;
+            this.autoSaveTitleLabel.Text = "str_wizard_autosave_title";
             // 
             // title
             // 
@@ -127,42 +136,79 @@ namespace PasteIntoFile
             this.title.Text = "str_wizard_title";
             this.title.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // subtitle1
+            // contextEntryTitleLabel
             // 
-            this.subtitle1.AutoSize = true;
-            this.subtitle1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.subtitle1.Location = new System.Drawing.Point(8, 116);
-            this.subtitle1.Margin = new System.Windows.Forms.Padding(4, 30, 4, 4);
-            this.subtitle1.Name = "subtitle1";
-            this.subtitle1.Size = new System.Drawing.Size(343, 32);
-            this.subtitle1.TabIndex = 1;
-            this.subtitle1.Text = "str_wizard_contextentry_title";
+            this.contextEntryTitleLabel.AutoSize = true;
+            this.contextEntryTitleLabel.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.contextEntryTitleLabel.Location = new System.Drawing.Point(8, 116);
+            this.contextEntryTitleLabel.Margin = new System.Windows.Forms.Padding(4, 30, 4, 4);
+            this.contextEntryTitleLabel.Name = "contextEntryTitleLabel";
+            this.contextEntryTitleLabel.Size = new System.Drawing.Size(343, 32);
+            this.contextEntryTitleLabel.TabIndex = 1;
+            this.contextEntryTitleLabel.Text = "str_wizard_contextentry_title";
             // 
-            // text1
+            // contextEntryInfoLabel
             // 
-            this.text1.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.text1.AutoSize = true;
-            this.text1.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.text1.Location = new System.Drawing.Point(8, 156);
-            this.text1.Margin = new System.Windows.Forms.Padding(4);
-            this.text1.Name = "text1";
-            this.text1.Size = new System.Drawing.Size(560, 23);
-            this.text1.TabIndex = 2;
-            this.text1.Text = "str_wizard_contextentry_info";
+            this.contextEntryInfoLabel.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.contextEntryInfoLabel.AutoSize = true;
+            this.contextEntryInfoLabel.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.contextEntryInfoLabel.Location = new System.Drawing.Point(8, 156);
+            this.contextEntryInfoLabel.Margin = new System.Windows.Forms.Padding(4);
+            this.contextEntryInfoLabel.Name = "contextEntryInfoLabel";
+            this.contextEntryInfoLabel.Size = new System.Drawing.Size(560, 23);
+            this.contextEntryInfoLabel.TabIndex = 2;
+            this.contextEntryInfoLabel.Text = "str_wizard_contextentry_info";
             // 
-            // chkContextEntry
+            // contextEntryCheckBox
             // 
-            this.chkContextEntry.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.chkContextEntry.AutoSize = true;
-            this.chkContextEntry.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
-            this.chkContextEntry.Location = new System.Drawing.Point(275, 192);
-            this.chkContextEntry.Margin = new System.Windows.Forms.Padding(9);
-            this.chkContextEntry.Name = "chkContextEntry";
-            this.chkContextEntry.Size = new System.Drawing.Size(288, 24);
-            this.chkContextEntry.TabIndex = 0;
-            this.chkContextEntry.Text = "str_wizard_contextentry_button";
-            this.chkContextEntry.UseVisualStyleBackColor = true;
-            this.chkContextEntry.CheckedChanged += new System.EventHandler(this.ChkContextEntry_CheckedChanged);
+            this.contextEntryCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.contextEntryCheckBox.AutoSize = true;
+            this.contextEntryCheckBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.contextEntryCheckBox.Location = new System.Drawing.Point(275, 192);
+            this.contextEntryCheckBox.Margin = new System.Windows.Forms.Padding(9);
+            this.contextEntryCheckBox.Name = "contextEntryCheckBox";
+            this.contextEntryCheckBox.Size = new System.Drawing.Size(288, 24);
+            this.contextEntryCheckBox.TabIndex = 0;
+            this.contextEntryCheckBox.Text = "str_wizard_contextentry_button";
+            this.contextEntryCheckBox.UseVisualStyleBackColor = true;
+            this.contextEntryCheckBox.CheckedChanged += new System.EventHandler(this.ChkContextEntry_CheckedChanged);
+            // 
+            // autostartTitleLabel
+            // 
+            this.autostartTitleLabel.AutoSize = true;
+            this.autostartTitleLabel.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.autostartTitleLabel.Location = new System.Drawing.Point(8, 116);
+            this.autostartTitleLabel.Margin = new System.Windows.Forms.Padding(4, 30, 4, 4);
+            this.autostartTitleLabel.Name = "autostartTitleLabel";
+            this.autostartTitleLabel.Size = new System.Drawing.Size(343, 32);
+            this.autostartTitleLabel.TabIndex = 1;
+            this.autostartTitleLabel.Text = "str_wizard_autostart_title";
+            // 
+            // autostartInfoLabel
+            // 
+            this.autostartInfoLabel.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.autostartInfoLabel.AutoSize = true;
+            this.autostartInfoLabel.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.autostartInfoLabel.Location = new System.Drawing.Point(8, 156);
+            this.autostartInfoLabel.Margin = new System.Windows.Forms.Padding(4);
+            this.autostartInfoLabel.Name = "autostartInfoLabel";
+            this.autostartInfoLabel.Size = new System.Drawing.Size(560, 23);
+            this.autostartInfoLabel.TabIndex = 2;
+            this.autostartInfoLabel.Text = "str_wizard_autostart_info";
+            // 
+            // autostartCheckBox
+            // 
+            this.autostartCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.autostartCheckBox.AutoSize = true;
+            this.autostartCheckBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            this.autostartCheckBox.Location = new System.Drawing.Point(275, 192);
+            this.autostartCheckBox.Margin = new System.Windows.Forms.Padding(9);
+            this.autostartCheckBox.Name = "autostartCheckBox";
+            this.autostartCheckBox.Size = new System.Drawing.Size(288, 24);
+            this.autostartCheckBox.TabIndex = 0;
+            this.autostartCheckBox.Text = "str_wizard_autostart_button";
+            this.autostartCheckBox.UseVisualStyleBackColor = true;
+            this.autostartCheckBox.CheckedChanged += new System.EventHandler(this.ChkAutostart_CheckedChanged);
             // 
             // finish
             // 
@@ -194,9 +240,9 @@ namespace PasteIntoFile
             this.AcceptButton = this.finish;
             this.AutoScaleDimensions = new System.Drawing.SizeF(144F, 144F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(576, 542);
+            this.ClientSize = new System.Drawing.Size(700, 850);
             this.Controls.Add(this.tableLayoutPanel1);
-            this.MinimumSize = new System.Drawing.Size(589, 572);
+            this.MinimumSize = new System.Drawing.Size(700, 850);
             this.Name = "Wizard";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Shown += new System.EventHandler(this.Wizard_Shown);
@@ -207,13 +253,16 @@ namespace PasteIntoFile
 
         private System.Windows.Forms.Label version;
         private System.Windows.Forms.Button finish;
-        private System.Windows.Forms.CheckBox chkContextEntry;
-        private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.Label text1;
+        private System.Windows.Forms.CheckBox contextEntryCheckBox;
+        private System.Windows.Forms.Label autoSaveTitleLabel;
+        private System.Windows.Forms.Label contextEntryInfoLabel;
         private System.Windows.Forms.Label title;
-        private System.Windows.Forms.CheckBox chkAutoSave;
-        private System.Windows.Forms.Label subtitle1;
-        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.CheckBox autoSaveCheckBox;
+        private System.Windows.Forms.Label contextEntryTitleLabel;
+        private System.Windows.Forms.Label autostartTitleLabel;
+        private System.Windows.Forms.CheckBox autostartCheckBox;
+        private System.Windows.Forms.Label autostartInfoLabel;
+        private System.Windows.Forms.Label autoSaveInfoLabel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
 
         #endregion

--- a/PasteIntoFile/Wizard.cs
+++ b/PasteIntoFile/Wizard.cs
@@ -23,7 +23,7 @@ namespace PasteIntoFile
             version.Text = string.Format(Resources.str_version, ProductVersion);
 
             chkAutoSave.Checked = Settings.Default.autoSave;
-            chkContextEntry.Checked = RegistryUtil.IsAppRegistered();
+            chkContextEntry.Checked = RegistryUtil.IsContextMenuEntryRegistered();
         }
 
         private void ChkAutoSave_CheckedChanged(object sender, EventArgs e)
@@ -37,14 +37,14 @@ namespace PasteIntoFile
         {
             try
             {
-                if (chkContextEntry.Checked && !RegistryUtil.IsAppRegistered())
+                if (chkContextEntry.Checked && !RegistryUtil.IsContextMenuEntryRegistered())
                 {
-                    RegistryUtil.RegisterApp();
+                    RegistryUtil.RegisterContextMenuEntry();
                     MessageBox.Show(Resources.str_message_register_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
-                else if (!chkContextEntry.Checked && RegistryUtil.IsAppRegistered())
+                else if (!chkContextEntry.Checked && RegistryUtil.IsContextMenuEntryRegistered())
                 {
-                    RegistryUtil.UnRegisterApp();
+                    RegistryUtil.UnRegisterContextMenuEntry();
                     MessageBox.Show(Resources.str_message_unregister_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }

--- a/PasteIntoFile/Wizard.cs
+++ b/PasteIntoFile/Wizard.cs
@@ -22,13 +22,14 @@ namespace PasteIntoFile
 
             version.Text = string.Format(Resources.str_version, ProductVersion);
 
-            chkAutoSave.Checked = Settings.Default.autoSave;
-            chkContextEntry.Checked = RegistryUtil.IsContextMenuEntryRegistered();
+            autoSaveCheckBox.Checked = Settings.Default.autoSave;
+            contextEntryCheckBox.Checked = RegistryUtil.IsContextMenuEntryRegistered();
+            autostartCheckBox.Checked = RegistryUtil.IsAutostartRegistered();
         }
 
         private void ChkAutoSave_CheckedChanged(object sender, EventArgs e)
         {
-            Settings.Default.autoSave = chkAutoSave.Checked;
+            Settings.Default.autoSave = autoSaveCheckBox.Checked;
             Settings.Default.Save();
 
         }
@@ -37,15 +38,36 @@ namespace PasteIntoFile
         {
             try
             {
-                if (chkContextEntry.Checked && !RegistryUtil.IsContextMenuEntryRegistered())
+                if (contextEntryCheckBox.Checked && !RegistryUtil.IsContextMenuEntryRegistered())
                 {
                     RegistryUtil.RegisterContextMenuEntry();
                     MessageBox.Show(Resources.str_message_register_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
-                else if (!chkContextEntry.Checked && RegistryUtil.IsContextMenuEntryRegistered())
+                else if (!contextEntryCheckBox.Checked && RegistryUtil.IsContextMenuEntryRegistered())
                 {
                     RegistryUtil.UnRegisterContextMenuEntry();
                     MessageBox.Show(Resources.str_message_unregister_context_menu_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message + "\n" + Resources.str_message_run_as_admin, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void ChkAutostart_CheckedChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                if (autostartCheckBox.Checked && !RegistryUtil.IsAutostartRegistered())
+                {
+                    RegistryUtil.RegisterAutostart();
+                    MessageBox.Show(Resources.str_message_register_autostart_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+                else if (!autostartCheckBox.Checked && RegistryUtil.IsAutostartRegistered())
+                {
+                    RegistryUtil.UnRegisterAutostart();
+                    MessageBox.Show(Resources.str_message_unregister_autostart_success, Resources.str_main_window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
             }
             catch (Exception ex)

--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ PasteIntoFile 4.0.0.0
 Copyright © PasteIntoFile GitHub contributors
 
   -d, --directory      Path of directory to save file into
-  -f, --filename       Filename template with optional date format variable such
-                       as {0:yyyyMMdd HHmmSS}
+  -f, --filename       Filename template with optional format variables such as
+                       {0:yyyyMMdd HHmmSS} for current date and time
+                       {1:000} for batch-mode save counter
   --text-extension     File extension for text contents
   --image-extension    File extension for image contents
+  --subdir             Template for name of subfolder to create when holding
+                       CTRL (see filename for format variables)
   -c, --clear          Clear clipboard after save (true/false)
   -a, --autosave       Autosave file without prompt (true/false)
   --help               Display this help screen.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
 [![Latest release](https://img.shields.io/github/v/release/eltos/PasteIntoFile)](https://github.com/eltos/PasteIntoFile/releases/latest)
 [![Total downloads](https://img.shields.io/github/downloads/eltos/PasteIntoFile/total)](https://github.com/eltos/PasteIntoFile/releases)
 
+## About
+
 A Windows desktop application to paste clipboard contents into files and copy file contents to the clipboard via the context menu
 
-----------------
+
 
 _This is a fork of [sorge13248/PasteIntoFile](https://github.com/sorge13248/PasteIntoFile), itself being a fork of [EslaMx7/PasteIntoFile](https://github.com/EslaMx7/PasteIntoFile)._
 _See the [contributors page](https://github.com/eltos/PasteIntoFile/graphs/contributors) for details on collaborators._  
-
-_This fork contains many new core functionalities such as clipboard monitoring, batch mode and rename inside the file explorer. In addition, the GUI was completely redesigned to make the layout resizeable and allow for comfortable text and image preview._
+_This fork comes with many new features such as clipboard monitoring, batch mode, rename inside file explorer, copy file contents, paste into subdirectory, support for many additional formats and a new GUI with fluid layout and comfortable text, image, HTML and richt-text preview._
 _The full changelog can be found on the [release page](https://github.com/eltos/PasteIntoFile/releases)._
 
-----------------
+
 
 ## Features
 
@@ -47,13 +48,23 @@ Further options can be accessed through the main GUI or via command line options
 
 Help is available via [GitHub discussions](https://github.com/eltos/PasteIntoFile/discussions/categories/q-a) 
 
+### Key modifiers
+
+Hold the following keys while launching Paste Into File
+- **SHIFT** inverts autosave settings once  
+  When autosave is enabled, holding SHIFT will show the dialog anyways  
+  When autosave is disabled, holding SHIFT will skip the dialog anyways
+- **CTRL** saves to a subdirectory  
+  Holding CTRL will save to an intermediate subdirectory  
+  The subfolder name supports templates and can be configured via command line options
+
 
 ## Command Line Use
 
 Use `help`, `help paste`, `help config` etc. to show available command line options, e.g.:
-```powershell
+```
 > .\PasteIntoFile.exe help
-PasteIntoFile 4.0.0.0
+PasteIntoFile 4.2.0.0
 Copyright © PasteIntoFile GitHub contributors
 
   paste      (Default Verb) Paste clipboard contents into file
@@ -65,7 +76,7 @@ Copyright © PasteIntoFile GitHub contributors
 ```
 ```
 > .\PasteIntoFile.exe help paste
-PasteIntoFile 4.0.0.0
+PasteIntoFile 4.2.0.0
 Copyright © PasteIntoFile GitHub contributors
 
   -d, --directory      Path of directory to save file into

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Hold the following keys while launching Paste Into File
 
 ## Command Line Use
 
-Use `help`, `help paste`, `help config` etc. to show available command line options, e.g.:
+Use `help`, `help paste`, `help config` etc. as argument to show available command line options, e.g.:
 ```
 > .\PasteIntoFile.exe help
 PasteIntoFile 4.2.0.0
@@ -95,13 +95,19 @@ Copyright © PasteIntoFile GitHub contributors
 ```
 
 **Examples:**
-- Add the *Paste Into File* entry in the File Explorer context menu:
+- Add/remove the *Paste Into File* entry in the File Explorer context menu:
    ```powershell
    PasteIntoFile config --register
+   PasteIntoFile config --unregister
    ``` 
-- Start *Paste Into File* in system tray and wait for hotkey Win + Alt + V:
+- Start *Paste Into File* manually in system tray and wait for hotkey Win + Alt + V:
    ```powershell
    PasteIntoFile tray
+   ``` 
+- En-/disable autostart of *Paste Into File* in system tray on windows startup:
+   ```powershell
+   PasteIntoFile config --enable-autostart
+   PasteIntoFile config --disable-autostart
    ``` 
 - Configure the default filename template format (see [format specifiers](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings)):
    ```powershell

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Windows desktop application to paste clipboard contents into files and copy fi
 
 _This is a fork of [sorge13248/PasteIntoFile](https://github.com/sorge13248/PasteIntoFile), itself being a fork of [EslaMx7/PasteIntoFile](https://github.com/EslaMx7/PasteIntoFile)._
 _See the [contributors page](https://github.com/eltos/PasteIntoFile/graphs/contributors) for details on collaborators._  
-_This fork comes with many new features such as clipboard monitoring, batch mode, rename inside file explorer, copy file contents, paste into subdirectory, support for many additional formats and a new GUI with fluid layout and comfortable text, image, HTML and richt-text preview._
+_This fork comes with many new features such as clipboard monitoring, batch mode, rename inside file explorer, copy file contents, paste into subdirectory, system tray mode, listen to hotkey, support for many additional formats and a new GUI with fluid layout and comfortable text, image, HTML and richt-text preview._
 _The full changelog can be found on the [release page](https://github.com/eltos/PasteIntoFile/releases)._
 
 
@@ -24,6 +24,7 @@ _The full changelog can be found on the [release page](https://github.com/eltos/
 + [Autosave mode](https://github.com/eltos/PasteIntoFile/discussions/2): rename inside file explorer without dialog
 + [Batch mode](https://github.com/eltos/PasteIntoFile/discussions/4): monitor clipboard and save on change
 + Many formats: Image, Text, HTML, CSV, URL, Rich Text Format, Data Interchange Format, Symbolic Link
++ Hotkey `Win`+`Alt`+`V`
 + First launch wizard
 
 ![Paste Into File](screenshot.png)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Copyright © PasteIntoFile GitHub contributors
   copy       Copy file contents to clipboard
   config     Change configuration (without saving clipboard)
   wizard     Open the first-launch wizard
+  tray       Open in tray and wait for hotkey Win + Alt + V
   help       Display more information on a specific command.
   version    Display version information.
 ```
@@ -97,6 +98,10 @@ Copyright © PasteIntoFile GitHub contributors
 - Add the *Paste Into File* entry in the File Explorer context menu:
    ```powershell
    PasteIntoFile config --register
+   ``` 
+- Start *Paste Into File* in system tray and wait for hotkey Win + Alt + V:
+   ```powershell
+   PasteIntoFile tray
    ``` 
 - Configure the default filename template format (see [format specifiers](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings)):
    ```powershell


### PR DESCRIPTION
- [x] Add command to open program into system tray
    Program will stay in the tray and listen for Hotkey WIN+ALT+V  
    SHIFT and CTRL modifiers as implemented in #7 also work
    ```powershell 
    .\PasteIntoFile.exe tray
    ```
- [x] Allow registering autostart into system tray on windows startup
    ```powershell 
    .\PasteIntoFile.exe config --enable-autostart
    .\PasteIntoFile.exe config --disable-autostart
    ```
- [x] Add description and checkbox to enable autostart to setup wizard  
      Replace "Context menu entry" checkbox on main window with link to setup wizard
- [x] (Un-)Register autostart during (un-)install
- [x] Add feature description to readme
- [x] This PR builds on top of #7, make sure to merge #7 first!

-----------
Related:
https://github.com/EslaMx7/PasteIntoFile/issues/36