### PR TITLE
Win8 compatibility

### DIFF
--- a/PasteIntoFile/ExplorerUtil.cs
+++ b/PasteIntoFile/ExplorerUtil.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using System.Threading.Tasks;
 using Shell32;
 
 namespace PasteIntoFile {
@@ -72,7 +73,9 @@ namespace PasteIntoFile {
         }
 
         /// <summary>
-        /// Request file name edit by user in active explorer path
+        /// Request file name edit by user in active explorer path.
+        /// This method will return immediately, and the FilenameEditComplete event handler
+        /// will be called asynchronously on success.
         /// </summary>
         /// <param name="filePath">Path of file to select/edit</param>
         /// <param name="edit">can be set to false to select only (without entering edit mode)</param>
@@ -101,7 +104,7 @@ namespace PasteIntoFile {
             SHParseDisplayName(filePath, IntPtr.Zero, out file, 0, out _);
             try {
                 SHOpenFolderAndSelectItems(file, 0, null, edit ? 1 : 0);
-                FilenameEditComplete?.Invoke(null, EventArgs.Empty);
+                Task.Run(() => FilenameEditComplete?.Invoke(null, EventArgs.Empty)); // call asynchronously
             } finally {
                 ILFree(file);
             }

--- a/PasteIntoFile/Main.cs
+++ b/PasteIntoFile/Main.cs
@@ -445,21 +445,33 @@ namespace PasteIntoFile {
         /// <param name="link">Optional link to visit when clicking the balloon</param>
         /// <param name="silent">If true, make a silent balloon (default)</param>
         public static void ShowBalloon(string title, string[] message, ushort expire = 5, string link = null, bool silent = true) {
-            var builder = new ToastContentBuilder().AddText(title);
-            foreach (var s in message) {
-                builder.AddText(s);
-            }
-            if (silent)
-                builder.AddAudio(null, null, true);
-
-            if (link != null)
-                builder.AddButton(Resources.str_open, ToastActivationType.Protocol, link);
-
-            builder.Show(toast => {
-                if (expire > 0) {
-                    toast.ExpirationTime = DateTime.Now.AddSeconds(expire);
+            try {
+                var builder = new ToastContentBuilder().AddText(title);
+                foreach (var s in message) {
+                    builder.AddText(s);
                 }
-            });
+
+                if (silent)
+                    builder.AddAudio(null, null, true);
+
+                if (link != null)
+                    builder.AddButton(Resources.str_open, ToastActivationType.Protocol, link);
+
+                builder.Show(toast => {
+                    if (expire > 0) {
+                        toast.ExpirationTime = DateTime.Now.AddSeconds(expire);
+                    }
+                });
+
+            } catch (SystemException) {
+                // Microsoft.Toolkit.Uwp requires Windows version 1809 (build 17763) or higher
+                // if that's not available, print to console instead
+                Console.WriteLine(title);
+                foreach (var s in message) {
+                    Console.WriteLine(s);
+                }
+
+            }
         }
 
 

--- a/PasteIntoFile/Main.cs
+++ b/PasteIntoFile/Main.cs
@@ -481,14 +481,14 @@ namespace PasteIntoFile {
         /// </summary>
         /// <returns>If an update is available</returns>
         public static async Task<bool> CheckForUpdates() {
-            if (!Settings.Default.updateChecksEnabled) return false;
+            if (!Settings.Default.updateChecksEnabled || Environment.OSVersion.Version.Major < 10) return false;
             bool newReleaseFound = false;
             if ((DateTime.Now - Settings.Default.updateLatestVersionLastCheck).TotalDays > 30) {
                 // Last check outdated, check again
                 Settings.Default.updateLatestVersionLastCheck = DateTime.Now;
                 Settings.Default.Save();
                 try {
-                    var client = new HttpClient();
+                    var client = new HttpClient(); // requires windows 10.0.10240.0
                     client.DefaultRequestHeaders.UserAgent.Add(new HttpProductInfoHeaderValue("PasteIntoFile", Application.ProductVersion));
                     var data = await client.GetStringAsync(new Uri("https://api.github.com/repos/eltos/PasteIntoFile/releases/latest"));
                     var match = Regex.Match(data, "\"(https://github.com/eltos/PasteIntoFile/releases/tag/v(\\d+(\\.\\d+)*))\"");

--- a/PasteIntoFile/Main.cs
+++ b/PasteIntoFile/Main.cs
@@ -5,8 +5,8 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using Windows.Web.Http;
-using Windows.Web.Http.Headers;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using CommandLine;
 using CommandLine.Text;
 using Microsoft.Toolkit.Uwp.Notifications;
@@ -481,15 +481,15 @@ namespace PasteIntoFile {
         /// </summary>
         /// <returns>If an update is available</returns>
         public static async Task<bool> CheckForUpdates() {
-            if (!Settings.Default.updateChecksEnabled || Environment.OSVersion.Version.Major < 10) return false;
+            if (!Settings.Default.updateChecksEnabled) return false;
             bool newReleaseFound = false;
             if ((DateTime.Now - Settings.Default.updateLatestVersionLastCheck).TotalDays > 30) {
                 // Last check outdated, check again
                 Settings.Default.updateLatestVersionLastCheck = DateTime.Now;
                 Settings.Default.Save();
                 try {
-                    var client = new HttpClient(); // requires windows 10.0.10240.0
-                    client.DefaultRequestHeaders.UserAgent.Add(new HttpProductInfoHeaderValue("PasteIntoFile", Application.ProductVersion));
+                    var client = new HttpClient();
+                    client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PasteIntoFile", Application.ProductVersion));
                     var data = await client.GetStringAsync(new Uri("https://api.github.com/repos/eltos/PasteIntoFile/releases/latest"));
                     var match = Regex.Match(data, "\"(https://github.com/eltos/PasteIntoFile/releases/tag/v(\\d+(\\.\\d+)*))\"");
                     if (match.Success && match.Groups[2].Value != Settings.Default.updateLatestVersion) {

--- a/PasteIntoFile/PasteIntoFile.csproj
+++ b/PasteIntoFile/PasteIntoFile.csproj
@@ -59,7 +59,7 @@
         <PackageReference Include="SharpClipboard" Version="3.5.2" />
         <PackageReference Include="Svg" Version="3.4.3" />
     </ItemGroup>
-    <ItemGroup Condition="'$(Flavor)'=='Portable'" >
+    <ItemGroup Condition="'$(Flavor)'=='Portable'">
         <PackageReference Include="PortableSettingsProvider" Version="0.2.4" />
     </ItemGroup>
     <ItemGroup>
@@ -72,6 +72,8 @@
         <Reference Include="System.Drawing.Design" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System.IO.Compression.FileSystem" />
+        <Reference Include="System.Net.Http" />
+        <Reference Include="System.Net.Http.WebRequest" />
         <Reference Include="System.Windows.Forms" />
         <Reference Include="System.Xml" />
     </ItemGroup>

--- a/PasteIntoFile/Properties/AssemblyInfo.cs
+++ b/PasteIntoFile/Properties/AssemblyInfo.cs
@@ -31,5 +31,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
+#if DEBUG
+[assembly: AssemblyVersion("5.1.*")]
+#else
 [assembly: AssemblyVersion("5.1")]
-[assembly: AssemblyFileVersion("5.1")]
+#endif

--- a/PasteIntoFile/Properties/Resources.Designer.cs
+++ b/PasteIntoFile/Properties/Resources.Designer.cs
@@ -662,6 +662,15 @@ namespace PasteIntoFile.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Notify about updates.
+        /// </summary>
+        internal static string str_wizard_notify_on_updates {
+            get {
+                return ResourceManager.GetString("str_wizard_notify_on_updates", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Welcome to Paste Into File.
         /// </summary>
         internal static string str_wizard_title {

--- a/PasteIntoFile/Properties/Resources.de.resx
+++ b/PasteIntoFile/Properties/Resources.de.resx
@@ -278,4 +278,7 @@ Diese Einstellungen werden ab dem nächsten Login aktiv.</value>
       <value>Speichert Dateien automatisch im Standarddateiformat ohne den Dialog zu zeigen.
 Die Umschalttaste gedrückt halten, um diese Einstellung temporär zu invertieren.</value>
   </data>
+  <data name="str_wizard_notify_on_updates" xml:space="preserve">
+      <value>Über Updates benachrichtigen</value>
+  </data>
 </root>

--- a/PasteIntoFile/Properties/Resources.resx
+++ b/PasteIntoFile/Properties/Resources.resx
@@ -287,4 +287,7 @@ These setting will take effect on the next login.</value>
     <value>Saves clipboard data to default filetype without prompt.
 Hold SHIFT to temporarly invert this setting.</value>
   </data>
+  <data name="str_wizard_notify_on_updates" xml:space="preserve">
+      <value>Notify about updates</value>
+  </data>
 </root>

--- a/PasteIntoFile/Wizard.Designer.cs
+++ b/PasteIntoFile/Wizard.Designer.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Drawing;
+using System.Windows.Forms;
 using PasteIntoFile.Properties;
 
 namespace PasteIntoFile {
@@ -280,6 +282,30 @@ namespace PasteIntoFile {
             this.version.Text = "version";
             this.version.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             //
+            // settings menu
+            //
+            this.settingsMenu = new ContextMenuStrip();
+            this.settingsMenu.AutoSize = true;
+            this.settingsMenuUpdateChecks = new ToolStripMenuItem();
+            this.settingsMenuUpdateChecks.CheckOnClick = true;
+            this.settingsMenuUpdateChecks.CheckedChanged += new EventHandler(this.menuUpdateChecks_CheckedChanged);
+            this.settingsMenuUpdateChecks.Text = Resources.str_wizard_notify_on_updates;
+            this.settingsMenu.Items.Add(this.settingsMenuUpdateChecks);
+            //
+            // settings button
+            //
+            this.settingsButton = new Label();
+            this.settingsButton.Text = "⚙️";
+            this.settingsButton.Font = new Font("Microsoft Sans Serif", 16F);
+            this.settingsButton.Location = new Point(0, 4);
+            this.settingsButton.Margin = new Padding(0);
+            this.settingsButton.Name = "settings";
+            this.settingsButton.TabIndex = 8;
+            this.settingsButton.AutoSize = true;
+            this.settingsButton.Cursor = Cursors.Hand;
+            this.settingsButton.Click += new EventHandler(this.settingsButton_Click);
+            this.Controls.Add(this.settingsButton);
+            //
             // Wizard
             //
             this.AcceptButton = this.finish;
@@ -296,6 +322,9 @@ namespace PasteIntoFile {
         }
 
         private System.Windows.Forms.CheckBox patchingCheckBox;
+        private System.Windows.Forms.Label settingsButton;
+        private System.Windows.Forms.ContextMenuStrip settingsMenu;
+        private System.Windows.Forms.ToolStripMenuItem settingsMenuUpdateChecks;
         private System.Windows.Forms.LinkLabel version;
         private System.Windows.Forms.Button finish;
         private System.Windows.Forms.CheckBox contextEntryCheckBoxPaste;

--- a/PasteIntoFile/Wizard.cs
+++ b/PasteIntoFile/Wizard.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using PasteIntoFile.Properties;
@@ -124,6 +125,22 @@ namespace PasteIntoFile {
                 Settings.Default.trayPatchingEnabled = patchingCheckBox.Checked;
                 Settings.Default.Save();
                 // no SavedAnimation so as not to give the feeling this would take effect immediately
+            }
+        }
+
+        private void settingsButton_Click(object sender, EventArgs e) {
+            // update
+            settingsMenuUpdateChecks.Checked = Settings.Default.updateChecksEnabled;
+            // show it
+            Point ptLowerLeft = new Point(4, settingsButton.Height);
+            ptLowerLeft = settingsButton.PointToScreen(ptLowerLeft);
+            settingsMenu.Show(ptLowerLeft);
+        }
+
+        private void menuUpdateChecks_CheckedChanged(object sender, EventArgs e) {
+            if (Settings.Default.updateChecksEnabled != settingsMenuUpdateChecks.Checked) {
+                Settings.Default.updateChecksEnabled = settingsMenuUpdateChecks.Checked;
+                Settings.Default.Save();
             }
         }
 

--- a/PasteIntoFile/app.manifest
+++ b/PasteIntoFile/app.manifest
@@ -29,20 +29,18 @@
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- A list of all Windows versions that this application is designed to work with. 
+      <!-- A list of all Windows versions that this application is designed to work with.
       Windows will automatically select the most compatible environment.-->
-
-      <!-- If your application is designed to work with Windows Vista, uncomment the following supportedOS node-->
-      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"></supportedOS>-->
-
-      <!-- If your application is designed to work with Windows 7, uncomment the following supportedOS node-->
-      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>-->
-
-      <!-- If your application is designed to work with Windows 8, uncomment the following supportedOS node-->
-      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"></supportedOS>-->
-
-      <!-- If your application is designed to work with Windows 8.1, uncomment the following supportedOS node-->
-      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>-->
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+      <!-- Windows 8.1 -->
+      <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
     </application>
   </compatibility>


### PR DESCRIPTION
<!-- Add a description of the goal of this merge request -->
<!-- List all introduced changes, features, etc. -->
Changes:
- Make Microsoft.Toolkit.Uwp notifications optional
  > Microsoft.Toolkit.Uwp requires Windows version 1809 (build 17763) or higher
  To ensure compatibility with older windows versions, exceptions with UWP notifications are caught.
  Notifications are not important for the functionality.
- Fix ObjectDisposedException due to Close() call in constructor
  > Exception was thrown after pasting in autosave mode completed and the app was closing down
- Use platform independent HttpClient
  > i.e. `System.Net.Http` instead of `Windows.Web.Http`


<!-- Link related issues or issues beeing fixed -->

Closes #32 

### Testing

<!-- Describe the steps taken to test the changes you've proposed -->

Tested by @wtfiwinomgs on Windows 8

<!-- Add screenshots/outputs/etc. of the behaviour before/after your changes -->

