### PR TITLE
Add format specifiers for day of year

### DIFF
--- a/PasteIntoFile/Dialog.cs
+++ b/PasteIntoFile/Dialog.cs
@@ -181,11 +181,19 @@ namespace PasteIntoFile {
         }
 
         public static string formatFilenameTemplate(string template, DateTime timestamp, int count) {
+            if (template.Contains("jjj"))
+                return timestamp.ToString("yyyy-") + timestamp.DayOfYear.ToString("000") + timestamp.ToString(" HH-mm-ss");
+
+            if (template.Contains('j'))
+                return timestamp.ToString("yyyy-") + timestamp.DayOfYear.ToString() + timestamp.ToString(" HH-mm-ss");
+
             return String.Format(template, timestamp, count);
         }
+
         public string formatFilenameTemplate(string template) {
             return formatFilenameTemplate(template, clipData.Timestamp, saveCount);
         }
+
         public void updateFilename(string filenameTemplate = null) {
             try {
                 txtFilename.Text = formatFilenameTemplate(filenameTemplate ?? Settings.Default.filenameTemplate);

--- a/PasteIntoFile/TemplateEdit.cs
+++ b/PasteIntoFile/TemplateEdit.cs
@@ -25,6 +25,8 @@ namespace PasteIntoFile {
             // setup predefined templates
             textTemplate.Items.AddRange(new object[]{
                 Settings.Default.filenameTemplate,
+                "{0:yyyy-j HH-mm-ss}",
+                "{0:yyyy-jjj HH-mm-ss}",
                 "{0:yyyy-MM-dd HH-mm-ss}",
                 "{0:yyyyMMdd_HHmmss}",
                 "{0:yyyy-MM-dd}_{1:000}",


### PR DESCRIPTION
- [x] Add two new file name templates: 
    1. `{0:yyyy-jjj HH-mm-ss}` for day of the year with leading zeroes
    2. `{0:yyyy-j HH-mm-ss}` for day of the year without leading zeroes

- [x] If the chosen format contains "jjj" or "j", format the file name accordingly. Otherwise use the standard format specifiers.


**Related Issue:** https://github.com/eltos/PasteIntoFile/issues/49