### PR TITLE
Run `dotnet restore` prior to formatting

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -36,6 +36,8 @@ jobs:
             # Install pre-commit
             python3 -m pip install pre-commit
             pre-commit install
+            # Restore
+            dotnet restore
             # Format files
             FILES=$(git diff --name-only HEAD origin/$GITHUB_BASE_REF | tr '\n' ' ')
             echo $FILES

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,8 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-python@v3
+            - name: Init
+              run: dotnet restore
             - uses: pre-commit/action@v3.0.1
               with:
                   extra_args: --all-files --hook-stage=manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: dotnet-format
         name: dotnet-format
         language: system
-        entry: dotnet format --include-generated --include
+        entry: dotnet restore; dotnet format --include-generated --include
         types_or: [ "c#", "vb" ]
   - repo: https://github.com/efrecon/pre-commit-hook-lxml
     rev: v0.1.4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: dotnet-format
         name: dotnet-format
         language: system
-        entry: dotnet restore; dotnet format --include-generated --include
+        entry: dotnet format --include-generated --include
         types_or: [ "c#", "vb" ]
   - repo: https://github.com/efrecon/pre-commit-hook-lxml
     rev: v0.1.4


### PR DESCRIPTION
Fixes CI errors occurring under some circumstances


-----
My contribution follows "inbound=outbound" licensing as defined by the [GitHub Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license).